### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/mvanderkamp/westures-core/security/code-scanning/1](https://github.com/mvanderkamp/westures-core/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token access unless overridden.  
For this workflow, `contents: read` is the minimal and sufficient permission for `actions/checkout` and CI read operations.

**Best fix (single change):**
- File: `.github/workflows/node.js.yml`
- Insert directly after the `on:` trigger block (before `jobs:`):
  ```yml
  permissions:
    contents: read
  ```
No imports, methods, or extra definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
