### PR TITLE
Tighten CI stability with pinned actions and reduced permissions

### DIFF
--- a/.github/workflows/deploy-documentation.yaml
+++ b/.github/workflows/deploy-documentation.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️ Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # This example project is built using npm and outputs the result to the
       # 'docs' folder.
@@ -32,7 +32,7 @@ jobs:
           npm run docs
 
       - name: 🚀 Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445 # v4.9.0
         with:
           # The folder the action should deploy.
           folder: docs

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,6 @@ jobs:
 
     permissions:
       contents: read
-      checks: write
 
     strategy:
       matrix:
@@ -43,7 +42,6 @@ jobs:
 
     permissions:
       contents: read
-      checks: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npm clean-install
+      - run: npm clean-install --ignore-scripts
       - run: npm run build
       - run: npm run lint
       - run: npm test
@@ -50,7 +50,7 @@ jobs:
         with:
           node-version: '22.x'
           cache: 'npm'
-      - run: npm clean-install
+      - run: npm clean-install --ignore-scripts
       - run: npm run build
       - run: npm run test:coverage
       - name: Upload coverage to Coveralls

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,9 +26,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -46,9 +46,9 @@ jobs:
       checks: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22.x'
           cache: 'npm'
@@ -56,6 +56,6 @@ jobs:
       - run: npm run build
       - run: npm run test:coverage
       - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,8 +6,7 @@ name: Node.js CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  pull_request: null
 
 permissions:
   contents: read
@@ -33,8 +32,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-      - run: npm ci
-      - run: npm run build --if-present
+      - run: npm clean-install
+      - run: npm run build
+      - run: npm run lint
       - run: npm test
 
   coverage:
@@ -52,8 +52,8 @@ jobs:
         with:
           node-version: '22.x'
           cache: 'npm'
-      - run: npm ci
-      - run: npm run build --if-present
+      - run: npm clean-install
+      - run: npm run build
       - run: npm run test:coverage
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION
## Description
- Enable cancellation of superseded CI runs per branch or pull request.
- Use  npm ci --ignore-scripts  to avoid duplicate builds triggered by the  prepare  lifecycle script.
- Reduce job permissions to explicit  contents: read .
- Pin checkout, Node setup, and Coveralls actions to immutable commit SHAs.

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 🧹 Chore / Refactor (code cleanup, npm package updates, linting)
